### PR TITLE
[EXPERIMENTAL][ARROW-6176][Python] Improve handling of extension types by ExtensionArray

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1689,6 +1689,9 @@ cdef class ExtensionArray(Array):
         result.validate()
         return result
 
+    def __getitem__(self, index):
+        return self.type.__storage_to_realized__(self.storage.__getitem__(index))
+
 
 cdef dict _array_classes = {
     _Type_NA: NullArray,

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -630,6 +630,9 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return NotImplementedError
 
+    @classmethod
+    def __storage_to_realized__(cls, scalar):
+        return NotImplementedError
 
 cdef class PyExtensionType(ExtensionType):
     """


### PR DESCRIPTION
When using extension types, it is not possible to work easily with arrays of the given type.  We are looking for an easy mechanism to make this more useful.  This PR contains efforts to that effect.